### PR TITLE
darewatch.py , Limit Links to 5 from 10

### DIFF
--- a/lib/lambdascrapers/sources_ lambdascrapers/en/darewatch.py
+++ b/lib/lambdascrapers/sources_ lambdascrapers/en/darewatch.py
@@ -115,7 +115,7 @@ class source:
             r = type('FailedResponse', (object,), {'ok': False})
 
         # On some movies there's like 20+ Openload links, most of the time there's no need for so many.
-        openload_limit = 10 # Set this as the maximum amount of Openload links obtained from Darewatch.
+        openload_limit = 5 # Set this as the maximum amount of Openload links obtained from Darewatch.
 
         if r.ok:
             match = re.findall("] = '(.+?)'", r.text, re.DOTALL)


### PR DESCRIPTION
just to many show up in the list . is 5 enough ? i think 10 is to much . 

Refereed to this by Doku , getting complaints on the forum

Mybee this can be changed to a Variable / string . and can be a Option in the settings ??  