### PR TITLE
Update CleanupService.py

### DIFF
--- a/CleanupService.py
+++ b/CleanupService.py
@@ -8,7 +8,7 @@ import xbmc
 import xbmcvfs
 import xbmcaddon
 
-from lambdascrapers import getAllHosters
+from lib.lambdascrapers import getAllHosters
 
 '''
 Temporary service to TRY to make some file changes, and then prevent itself from running again.

--- a/CleanupService.py
+++ b/CleanupService.py
@@ -11,7 +11,7 @@ import xbmcaddon
 from lambdascrapers import getAllHosters
 
 '''
-Temporary service to TRY to make some file changes, and then remove itself from running again.
+Temporary service to TRY to make some file changes, and then prevent itself from running again.
 '''
 
 ADDON = xbmcaddon.Addon()


### PR DESCRIPTION
Variation on that cleanup-service thing:  
- The service cleans out obsolete providers from the user-settings file.
- The service is now disabled by commenting it out from the addon.xml file, instead of deleting the script altogether. So the script will remain installed (it's really small anyway, 2 KB), but made inactive.

**Note:** needs testing.