### PR TITLE
Cached torrents scrapers

### DIFF
--- a/lib/default.py
+++ b/lib/default.py
@@ -77,6 +77,10 @@ if mode == "toggleAllForeign":
     'filmwebbooster','iitv','movieneo','openkatalog','paczamy','segos','szukajkatv','trt']
     toggleAll(params['setting'], params['open_id'], sourcelist)
 
+if mode == "toggleAllTorrent":
+    sourcelist = ['1337x','bitlord','magnetdl','torrentapi']
+    toggleAll(params['setting'], params['open_id'], sourcelist)
+
 if mode == "Defaults":
     sourcelist = ['4kmovieto','1080P','bobmovies','bnwmovies',
     'cartoonhd','coolmoviezone','darewatch','divxcrawler',

--- a/lib/lambdascrapers/sources_ lambdascrapers/en_Torrent/1337x.py
+++ b/lib/lambdascrapers/sources_ lambdascrapers/en_Torrent/1337x.py
@@ -1,0 +1,99 @@
+'''
+    Created by others
+    Refactored for lambdascrapers
+    Nov 20 2018
+'''
+
+import re, requests
+from resolveurl.plugins.premiumize_me import PremiumizeMeResolver
+from resources.lib.modules import source_utils
+
+class source:
+
+    def __init__(self):
+        self.api_key = PremiumizeMeResolver.get_setting('password')
+        self.priority = 1
+        self.language = ['en']
+        self.domain = 'https://1337xx.top'
+        self.search_link = 'https://1337xx.top/search.php?q=%s'
+        self.checkc = 'https://www.premiumize.me/api/torrent/checkhashes?apikey=%s&hashes[]=%s&apikey=%s'
+        self.pr_link = 'https://www.premiumize.me/api/transfer/directdl?apikey=%s&src=magnet:?xt=urn:btih:%s'
+
+    def movie(self, imdb, title, localtitle, aliases, year):
+        try:
+            url = {'title': title, 'year': year}
+            return url
+        except:
+            print("Unexpected error in 1337xx Script: episode", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return url
+
+    def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
+        try:
+            url = tvshowtitle
+            return url
+        except:
+            print("Unexpected error in 1337xx Script: TV", sys.exc_info()[0])
+            return url
+        return url
+
+    def episode(self, url, imdb, tvdb, title, premiered, season, episode):
+        try:
+            url = url
+            url = {'tvshowtitle': url, 'season': season, 'episode': episode, 'premiered': premiered}
+            return url
+        except:
+            print("Unexpected error in 1337xx Script: episode", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return url
+
+    def sources(self, url, hostDict, hostprDict):
+        sources = []
+        try:
+            with requests.Session() as s:
+                if 'episode' in url:
+                    iep = url['episode'].zfill(2)
+                    ise = url['season'].zfill(2)
+                    se = 's' + ise + 'e' + iep
+                    sel = url['tvshowtitle'].replace(' ','+') + '+' + se
+                   
+                else:
+                    se = url['year']
+                    sel = url['title'].replace(' ','+') + '+' + se
+                    
+                   
+                gs = s.get(self.search_link % (sel)).text
+                gl = re.compile('f\W+(/t.*?)"\st.*?'+se, re.I).findall(gs)
+                for res in gl:
+                    rih = s.get(self.domain+res).text
+                    gih = re.compile('Size.*?n>(.*?)<.*?hash.*?n\W+(.*?)\W.*?>D\w+(.*?)<', re.DOTALL).findall(rih)
+                    for si,hass,nam in gih:
+                        checkca = s.get(self.checkc % (self.api_key, hass, self.api_key)).text
+                        quality = source_utils.check_sd_url(nam)
+                        if 'finished' in checkca:
+                            url = self.pr_link % (self.api_key, hass)
+                            sources.append({
+                                'source': 'cached',
+                                'quality': quality,
+                                'language': 'en',
+                                'url': url,
+                                'direct': False,
+                                'debridonly': False,
+                                'info': si+'|'+nam,
+                            })
+                            
+            return sources
+        except:
+            print("Unexpected error in 1337xx Script: Sources", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return sources
+
+        
+    def resolve(self, url):
+        getpl = requests.get(url).text
+        sl = re.compile('link.*?"(h.*?)["\'].\n.*?s.*?http', re.I).findall(getpl)[0]
+        url = sl.replace('\\','')
+        return url

--- a/lib/lambdascrapers/sources_ lambdascrapers/en_Torrent/bitlord.py
+++ b/lib/lambdascrapers/sources_ lambdascrapers/en_Torrent/bitlord.py
@@ -4,14 +4,14 @@
     Nov 20 2018
 '''
 
-import re, requests, xbmc
-from resolveurl.plugins.premiumize_me import PremiumizeMeResolver
+import re, requests
 from resources.lib.modules import source_utils
+from resolveurl.plugins.premiumize_me import PremiumizeMeResolver
 
 class source:
 
     def __init__(self):
-        self.priority = 0
+        self.priority = 1
         self.language = ['en']
         self.domain = 'http://www.bitlordsearch.com'
         self.api_key = PremiumizeMeResolver.get_setting('password')
@@ -64,21 +64,16 @@ class source:
                     ise = url['season'].zfill(2)
                     se = 's' + ise + 'e' + iep
                     sel = url['tvshowtitle'].replace(' ','.') + '.' + se
-                    cate = '4'
-                    
+                    cate = '4'  
                 else:
                     sel = url['title'].replace(' ','.') + '.' + url['year']
                     cate = '3'
-                    
                 sel = sel.lower()
                 bdata = {'filters[adult]': 'false', 'filters[category]': cate, 'filters[field]': 'category', 'filters[sort]': 'asc',\
                          'filters[time]': '4', 'limit': '25', 'offset': '0', 'query': sel}
-                
                 gs = s.post(self.search_link, data=bdata).text
-                
-                gl = re.compile('me\W+(.*?)[\'"].*?tih:(.*?)\W', re.I).findall(gs)
-                for nam,haas in gl:
-                    print('FDGDFGDFGFD-----45345345', haas)
+                gl = re.compile('me\W+(.*?)[\'"].*?tih:(.*?)\W.*?ize\W+(.*?)\W', re.I).findall(gs)
+                for nam,haas,siz in gl:
                     checkca = s.get(self.checkc % (self.api_key, haas, self.api_key)).text
                     quality = source_utils.check_sd_url(nam)
                     if 'finished' in checkca:
@@ -90,7 +85,7 @@ class source:
                             'url': url,
                             'direct': False,
                             'debridonly': False,
-                            'info': nam,
+                            'info': siz+' MB''|'+nam,
                         })  
             return sources
         except:
@@ -101,13 +96,7 @@ class source:
 
         
     def resolve(self, url):
-        try:
-            getpl = requests.get(url).text
-            sl = re.compile('link.*?"(h.*?)["\'].\n.*?s.*?http', re.I).findall(getpl)[0]
-            url = sl.replace('\\','')
-            return url
-        except:
-            print("Unexpected error in BitLord Script: episode", sys.exc_info()[0])
-            exc_type, exc_obj, exc_tb = sys.exc_info()
-            print(exc_type, exc_tb.tb_lineno)
-            return url
+        getpl = requests.get(url).text
+        sl = re.compile('link.*?"(h.*?)["\'].\n.*?s.*?http', re.I).findall(getpl)[0]
+        url = sl.replace('\\','')
+        return url

--- a/lib/lambdascrapers/sources_ lambdascrapers/en_Torrent/bitlord.py
+++ b/lib/lambdascrapers/sources_ lambdascrapers/en_Torrent/bitlord.py
@@ -1,0 +1,113 @@
+'''
+    Created by others
+    Refactored for lambdascrapers
+    Nov 20 2018
+'''
+
+import re, requests, xbmc
+from resolveurl.plugins.premiumize_me import PremiumizeMeResolver
+from resources.lib.modules import source_utils
+
+class source:
+
+    def __init__(self):
+        self.priority = 0
+        self.language = ['en']
+        self.domain = 'http://www.bitlordsearch.com'
+        self.api_key = PremiumizeMeResolver.get_setting('password')
+        self.search_link = 'http://www.bitlordsearch.com/get_list'
+        self.checkc = 'https://www.premiumize.me/api/torrent/checkhashes?apikey=%s&hashes[]=%s&apikey=%s'
+        self.pr_link = 'https://www.premiumize.me/api/transfer/directdl?apikey=%s&src=magnet:?xt=urn:btih:%s'
+
+    def movie(self, imdb, title, localtitle, aliases, year):
+        try:
+            url = {'title': title, 'year': year}
+            return url
+        except:
+            print("Unexpected error in BitLord Script: episode", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return url
+
+    def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
+        try:
+            url = tvshowtitle
+            return url
+        except:
+            print("Unexpected error in BitLord Script: TV", sys.exc_info()[0])
+            return url
+        return url
+
+    def episode(self, url, imdb, tvdb, title, premiered, season, episode):
+        try:
+            url = url
+            url = {'tvshowtitle': url, 'season': season, 'episode': episode, 'premiered': premiered}
+            return url
+        except:
+            print("Unexpected error in BitLord Script: episode", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return url
+
+    def sources(self, url, hostDict, hostprDict):
+        sources = []
+        try:
+            with requests.Session() as s:
+                headers = {"Referer": self.domain,\
+                           "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",\
+                           "Host": "www.BitLord.com","User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:59.0) Gecko/20100101 Firefox/59.0",\
+                           "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",\
+                           "Accept-Encoding": "gzip, deflate, br","Accept-Language": "en-US,en;q=0.5",\
+                           "Connection": "keep-alive","DNT":"1"}
+                if 'episode' in url:
+                    iep = url['episode'].zfill(2)
+                    ise = url['season'].zfill(2)
+                    se = 's' + ise + 'e' + iep
+                    sel = url['tvshowtitle'].replace(' ','.') + '.' + se
+                    cate = '4'
+                    
+                else:
+                    sel = url['title'].replace(' ','.') + '.' + url['year']
+                    cate = '3'
+                    
+                sel = sel.lower()
+                bdata = {'filters[adult]': 'false', 'filters[category]': cate, 'filters[field]': 'category', 'filters[sort]': 'asc',\
+                         'filters[time]': '4', 'limit': '25', 'offset': '0', 'query': sel}
+                
+                gs = s.post(self.search_link, data=bdata).text
+                
+                gl = re.compile('me\W+(.*?)[\'"].*?tih:(.*?)\W', re.I).findall(gs)
+                for nam,haas in gl:
+                    print('FDGDFGDFGFD-----45345345', haas)
+                    checkca = s.get(self.checkc % (self.api_key, haas, self.api_key)).text
+                    quality = source_utils.check_sd_url(nam)
+                    if 'finished' in checkca:
+                        url = self.pr_link % (self.api_key, haas)
+                        sources.append({
+                            'source': 'cached',
+                            'quality': quality,
+                            'language': 'en',
+                            'url': url,
+                            'direct': False,
+                            'debridonly': False,
+                            'info': nam,
+                        })  
+            return sources
+        except:
+            print("Unexpected error in BitLord Script: Sources", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return sources
+
+        
+    def resolve(self, url):
+        try:
+            getpl = requests.get(url).text
+            sl = re.compile('link.*?"(h.*?)["\'].\n.*?s.*?http', re.I).findall(getpl)[0]
+            url = sl.replace('\\','')
+            return url
+        except:
+            print("Unexpected error in BitLord Script: episode", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return url

--- a/lib/lambdascrapers/sources_ lambdascrapers/en_Torrent/magnetdl.py
+++ b/lib/lambdascrapers/sources_ lambdascrapers/en_Torrent/magnetdl.py
@@ -83,7 +83,7 @@ class source:
                             'url': url,
                             'direct': False,
                             'debridonly': False,
-                            'info': siz+' '+nam,
+                            'info': siz+'|'+nam,
                         })  
             return sources
         except:

--- a/lib/lambdascrapers/sources_ lambdascrapers/en_Torrent/magnetdl.py
+++ b/lib/lambdascrapers/sources_ lambdascrapers/en_Torrent/magnetdl.py
@@ -1,0 +1,106 @@
+'''
+    Created by others
+    Refactored for lambdascrapers
+    Nov 20 2018
+'''
+
+import re, requests, xbmc
+from resolveurl.plugins.premiumize_me import PremiumizeMeResolver
+from resources.lib.modules import source_utils
+
+class source:
+
+    def __init__(self):
+        self.priority = 1
+        self.language = ['en']
+        self.domain = 'http://www.magnetdl.com'
+        self.api_key = PremiumizeMeResolver.get_setting('password')
+        self.search_link = 'http://www.magnetdl.com/%s/%s/'
+        self.checkc = 'https://www.premiumize.me/api/torrent/checkhashes?apikey=%s&hashes[]=%s&apikey=%s'
+        self.pr_link = 'https://www.premiumize.me/api/transfer/directdl?apikey=%s&src=magnet:?xt=urn:btih:%s'
+
+    def movie(self, imdb, title, localtitle, aliases, year):
+        try:
+            url = {'title': title, 'year': year}
+            return url
+        except:
+            print("Unexpected error in MagnetDL Script: episode", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return url
+
+    def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
+        try:
+            url = tvshowtitle
+            return url
+        except:
+            print("Unexpected error in MagnetDL Script: TV", sys.exc_info()[0])
+            return url
+        return url
+
+    def episode(self, url, imdb, tvdb, title, premiered, season, episode):
+        try:
+            url = url
+            url = {'tvshowtitle': url, 'season': season, 'episode': episode, 'premiered': premiered}
+            return url
+        except:
+            print("Unexpected error in MagnetDL Script: episode", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return url
+
+    def sources(self, url, hostDict, hostprDict):
+        sources = []
+        try:
+            with requests.Session() as s:
+                headers = {"Referer": self.domain,\
+                           "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",\
+                           "Host": "www.magnetdl.com","User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:59.0) Gecko/20100101 Firefox/59.0",\
+                           "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",\
+                           "Accept-Encoding": "gzip, deflate, br","Accept-Language": "en-US,en;q=0.5",\
+                           "Connection": "keep-alive","DNT":"1"}
+                if 'episode' in url:
+                    iep = url['episode'].zfill(2)
+                    ise = url['season'].zfill(2)
+                    se = 's' + ise + 'e' + iep
+                    sel = url['tvshowtitle'].replace(' ','-') + '-' + se
+                    
+                else:
+                    sel = url['title'].replace(' ','-') + '-' + url['year']
+                    
+                sel = sel.lower()
+                gs = s.get(self.search_link % (sel[0], sel), headers=headers).text
+                gl = re.compile('ih:(.*?)\W.*?ef\W+.*?tle\W+(.*?)[\'"].*?\d</td.*?d>(.*?)<', re.I).findall(gs)
+                for hass,nam,siz in gl:
+                    checkca = s.get(self.checkc % (self.api_key, hass, self.api_key)).text
+                    quality = source_utils.check_sd_url(nam)
+                    if 'finished' in checkca:
+                        url = self.pr_link % (self.api_key, hass)
+                        sources.append({
+                            'source': 'cached',
+                            'quality': quality,
+                            'language': 'en',
+                            'url': url,
+                            'direct': False,
+                            'debridonly': False,
+                            'info': siz+' '+nam,
+                        })  
+            return sources
+        except:
+            print("Unexpected error in MagnetDL Script: Sources", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return sources
+
+        
+    def resolve(self, url):
+        try:
+            getpl = requests.get(url).text
+            sl = re.compile('link.*?"(h.*?)["\'].\n.*?s.*?http', re.I).findall(getpl)[0]
+            url = sl.replace('\\','')
+            return url
+        except:
+            print("Unexpected error in MagnetDL Script: episode", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return url

--- a/lib/lambdascrapers/sources_ lambdascrapers/en_Torrent/torrentapi.py
+++ b/lib/lambdascrapers/sources_ lambdascrapers/en_Torrent/torrentapi.py
@@ -1,0 +1,104 @@
+'''
+    Created by others
+    Refactored for lambdascrapers
+    Nov 20 2018
+'''
+
+import re, requests, xbmc
+from resolveurl.plugins.premiumize_me import PremiumizeMeResolver
+from resources.lib.modules import source_utils
+
+class source:
+
+    def __init__(self):
+        self.priority = 1
+        self.language = ['en']
+        self.domain = 'https://Torrentapi.top'
+        self.api_key = PremiumizeMeResolver.get_setting('password')
+        self.tvsearch = 'https://torrentapi.org//pubapi_v2.php?app_id=exodus&mode=search&search_string=%s&category=tv&ranked=0&token=%s'
+        self.msearch = 'https://torrentapi.org//pubapi_v2.php?app_id=exodus&mode=search&search_string=%s&category=movies&ranked=0&token=%s'
+        self.tokenta = 'https://torrentapi.org//pubapi_v2.php?app_id=exodus&get_token=get_token'
+        self.checkc = 'https://www.premiumize.me/api/torrent/checkhashes?apikey=%s&hashes[]=%s&apikey=%s'
+        self.pr_link = 'https://www.premiumize.me/api/transfer/directdl?apikey=%s&src=magnet:?xt=urn:btih:%s'
+
+    def movie(self, imdb, title, localtitle, aliases, year):
+        try:
+            url = {'title': title, 'year': year}
+            return url
+        except:
+            print("Unexpected error in Torrentapi Script: episode", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return url
+
+    def tvshow(self, imdb, tvdb, tvshowtitle, localtvshowtitle, aliases, year):
+        try:
+            url = tvshowtitle
+            return url
+        except:
+            print("Unexpected error in Torrentapi Script: TV", sys.exc_info()[0])
+            return url
+        return url
+
+    def episode(self, url, imdb, tvdb, title, premiered, season, episode):
+        try:
+            url = url
+            url = {'tvshowtitle': url, 'season': season, 'episode': episode, 'premiered': premiered}
+            return url
+        except:
+            print("Unexpected error in Torrentapi Script: episode", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return url
+
+    def sources(self, url, hostDict, hostprDict):
+        sources = []
+        try:
+            with requests.Session() as s:
+                gettoken = s.get(self.tokenta).text
+                xbmc.sleep(2000)
+                tokenapi = re.compile('n\W+(.*?)[\'"]', re.I).findall(gettoken)[0]
+                if 'episode' in url:
+                    iep = url['episode'].zfill(2)
+                    ise = url['season'].zfill(2)
+                    se = 's' + ise + 'e' + iep
+                    sel = url['tvshowtitle'].replace(' ','.') + '.' + se
+                    search_link = self.tvsearch
+                else:
+                    sel = url['title'].replace(' ','.') + '.' + url['year']
+                    search_link = self.msearch
+                gs = s.get(search_link % (sel, tokenapi)).text
+                gl = re.compile('ame\W+(.*?)[\'"].*?ih:(.*?)\W', re.I).findall(gs)
+                for nam,hass in gl:
+                    checkca = s.get(self.checkc % (self.api_key, hass, self.api_key)).text
+                    quality = source_utils.check_sd_url(nam)
+                    if 'finished' in checkca:
+                        url = self.pr_link % (self.api_key, hass)
+                        sources.append({
+                            'source': 'cached',
+                            'quality': quality,
+                            'language': 'en',
+                            'url': url,
+                            'direct': False,
+                            'debridonly': False,
+                            'info': nam,
+                        })  
+            return sources
+        except:
+            print("Unexpected error in Torrentapi Script: Sources", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return sources
+
+        
+    def resolve(self, url):
+        try:
+            getpl = requests.get(url).text
+            sl = re.compile('link.*?"(h.*?)["\'].\n.*?s.*?http', re.I).findall(getpl)[0]
+            url = sl.replace('\\','')
+            return url
+        except:
+            print("Unexpected error in Torrentapi Script: episode", sys.exc_info()[0])
+            exc_type, exc_obj, exc_tb = sys.exc_info()
+            print(exc_type, exc_tb.tb_lineno)
+            return url

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -210,6 +210,17 @@
         <setting id="provider.ultrahdindir" type="bool" label="ULTRAHDINDIR" default="false" /> <!--Lambdascrapers-->
         <setting id="provider.wrzcraft" type="bool" label="WRZCRAFT" default="false" /> <!--Incursion--> <!--Placenta--> <!--Lambdascrapers-->
     </category>
+
+    <category label="Torrent (cached)">
+        <setting label="Disable All Torrent Providers" type="action" option="close" action="RunPlugin(plugin://script.module.lambdascrapers/?mode=toggleAllTorrent&amp;setting=false&amp;open_id='1.1')"/>
+        <setting label="Enable All Torrent Providers" type="action" option="close" action="RunPlugin(plugin://script.module.lambdascrapers/?mode=toggleAllTorrent&amp;setting=true&amp;open_id='1.2')"/>
+        <setting type="sep" />
+        <setting id="provider.1337x" type="bool" label="$NUMBER[1337]X" default="false" />
+        <setting id="provider.bitlord" type="bool" label="BITLORD" default="false" />
+        <setting id="provider.magnetdl" type="bool" label="MAGNETDL" default="false" />
+        <setting id="provider.torrentapi" type="bool" label="TORRENTAPI" default="false" />
+    </category>
+
 <!--    <category label="Debug">\-->
 <!--        <setting id="addon_debug" type="bool" label="Enable Debug" default="false" />-->
 <!--    </category>-->


### PR DESCRIPTION
https://www.reddit.com/r/Addons4Kodi/comments/9y1qc7/cached_torrent_scrapers_for_exodus_forks/
#44 

For these to work, a FREE premiumize account is required. But unfortunately this is temporary, because (as I heard) pm will only give free access to it's cache until Dec 1.
All needed is to enter your pm PIN in resolveurl's settings.
However I found some problems with that:
- If you enter only the PIN, I see some weird behavior on sources fetching: The sources fetching dialog freezes (I guess when a torrent scraper utilizes), but the scraping gets done on the background, and eventually shows the results.
- If you enter the Customer ID as well, the above problem does not occur, but you'll get normal (hoster) results resolved by premiumize as well, which if you don't have premium account will be unplayable.

Choose your poison.

I added the scrapers in a new category [Torrents (cached)] and disabled by default. Ie same behavior as debrid-only scrapers.
I also polished the originals (NOT written by me) a bit, to fetch correct quality, file, file size/name.
